### PR TITLE
fix: changed the default console sink log level for error to ERROR instead of WARN

### DIFF
--- a/src/prettyPrinter.ts
+++ b/src/prettyPrinter.ts
@@ -8,7 +8,7 @@ import { formatWithOptions } from "./runtime/util.inspect.polyfil";
 export type Sink = (formattedString: string, logLevelId: number) => void;
 
 export const ConsoleSink = (formattedString: string, logLevelId: number) => {
-    if (logLevelId >= LogLevel.WARN) {
+    if (logLevelId >= LogLevel.ERROR) {
         console.error(formattedString);
     } else {
         console.log(formattedString);


### PR DESCRIPTION
There's a philosophical question around whether a warning is an error, but in this case, it's really not.